### PR TITLE
fix: invalid syntax

### DIFF
--- a/format/action.yml
+++ b/format/action.yml
@@ -7,7 +7,7 @@ runs:
         pnpm format
         echo "RESULT=${git diff --shortstat)" >> $GITHUB_OUTPUT
       shell: bash
-    - if: steps.format.outputs.RESULT != ""
+    - if: steps.format.outputs.RESULT != ''
       name: Commit a diff
       run: |
         git -c "user.name=${{ github.actor }}" -c "user.email=${{ github.actor }}@users.noreply.github.com" commit -a -m "format [skip ci]"


### PR DESCRIPTION
使用時次のログが出力されることに対処します

```
Error: tuqulore/.github/main/format/action.yml (Line: 10, Col: 11): Unexpected symbol: '""'. Located at position 32 within expression: steps.format.outputs.RESULT != ""
Error: GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. tuqulore/.github/main/format/action.yml (Line: 10, Col: 11): Unexpected symbol: '""'. Located at position 32 within expression: steps.format.outputs.RESULT != ""
   at GitHub.DistributedTask.ObjectTemplating.TemplateValidationErrors.Check()
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load tuqulore/.github/main/format/action.yml
```