### PR TITLE
actions: add workflow templates for CI, Release, and Publish

### DIFF
--- a/resolve-target-sha/action.yml
+++ b/resolve-target-sha/action.yml
@@ -1,0 +1,34 @@
+name: Resolve target sha
+description: |
+  Resolve the commit SHA to use for publishing/tagging based on the workflow
+  trigger event. For pull_request events the merge_commit_sha is used; for
+  workflow_dispatch (or any other event) the latest origin/<default-branch>
+  HEAD is used. Fetches origin/<default-branch> first so the SHA is reachable
+  for subsequent git operations (git show, git tag, git checkout).
+inputs:
+  default-branch:
+    description: Default branch name to fetch and to use as fallback.
+    required: true
+outputs:
+  sha:
+    description: Resolved commit SHA.
+    value: ${{ steps.resolve.outputs.sha }}
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        DEFAULT_BRANCH: ${{ inputs.default-branch }}
+      run: |
+        git fetch origin "${DEFAULT_BRANCH}"
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          if [ -z "${SHA}" ]; then
+            echo "::error::pull_request.merge_commit_sha is empty. Re-run the workflow once the merge commit has been propagated." >&2
+            exit 1
+          fi
+        else
+          SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
+        fi
+        echo "sha=${SHA}" >> "$GITHUB_OUTPUT"

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,0 +1,69 @@
+# Workflow templates
+
+tuqulore 組織で共通利用するための GitHub Actions ワークフローテンプレート集。
+
+| テンプレート | 用途 |
+| ------------ | ---- |
+| [`ci.yml`](./ci.yml) | push 起動で lint / test を実行し、フォーマット差分を自動コミット |
+| [`release.yml`](./release.yml) | `workflow_dispatch` で起動し、release ブランチでリリース PR を作成 (lerna monorepo) |
+| [`publish.yml`](./publish.yml) | リリース PR のマージで起動し、npm 公開 → タグ作成 → alpha バンプ PR (lerna monorepo) |
+
+利用側のリポジトリでは GitHub UI の「New workflow」画面から該当テンプレートを選んで生成する。生成された yaml は通常のワークフロー扱いなので、リポジトリに合わせて自由に編集してよい。
+
+## 共通前提
+
+### Composite action への依存
+
+すべてのテンプレートは `tuqulore/.github` リポジトリ内の以下の composite action を `@main` で参照する。テンプレートを使うには利用側のリポジトリから本リポジトリにアクセスできる必要がある (public リポジトリのため通常は問題なし)。
+
+| Composite action | 役割 |
+| ---------------- | ---- |
+| [`setup`](../setup/action.yml) | `actions/checkout` + pnpm + Node.js のセットアップと `pnpm install` |
+| [`configure-git`](../configure-git/action.yml) | CI 内でのコミット用に git の user.name / user.email を設定 |
+| [`format`](../format/action.yml) | `pnpm format` を実行して差分を自動コミット |
+| [`bump-and-pr`](../bump-and-pr) | バージョン bump → ブランチ作成 → PR 作成を 1 ステップで行う |
+| [`resolve-target-sha`](../resolve-target-sha/action.yml) | publish 対象の SHA を `pull_request` / `workflow_dispatch` の両イベントから解決 |
+
+`@main` を SHA pin に置き換える運用は、利用側のリポジトリで `actions: write` の編集権限を持つメンバーが行ってよい (renovate がアップデート提案を出す)。
+
+### `$default-branch` プレースホルダ
+
+テンプレート内の `$default-branch` は GitHub がテンプレート生成時に利用側リポジトリのデフォルトブランチ名 (通常は `main`) に自動置換する。よってデフォルトブランチが `main` でないリポジトリでもそのまま動く。
+
+### lerna monorepo 前提 (Release / Publish)
+
+`release.yml` と `publish.yml` は lerna monorepo を前提に設計されている。具体的には:
+
+- バージョン管理: `lerna.json` の `version` を `jq -r .version lerna.json` で取得
+- バージョン bump: `pnpm packages:bump-version <semver>` (利用側で `lerna version` をラップするスクリプトを `packages:bump-version` として定義しておく)
+- 公開: `pnpm packages:publish` (利用側で `lerna publish from-package` 等をラップする)
+
+単一パッケージ (`package.json` の `version` を使う) の場合は、生成後のワークフロー内で `version-command` と `bump-command` を書き換える必要がある。
+
+### npm Trusted Publishing 前提 (Publish)
+
+`publish.yml` の npm 公開ステップは npm の Trusted Publishing (OIDC) を使う前提で書かれている。利用側のパッケージごとに、npm 側で「Trusted Publisher」として **このリポジトリの `publish` ワークフロー** を登録しておく必要がある。詳しくは [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) を参照。
+
+従来のトークン方式 (`NODE_AUTH_TOKEN` + `.npmrc`) に切り替える場合は、生成されたワークフローに `setup-node` の `registry-url` 設定と `NODE_AUTH_TOKEN` の受け渡しを追加する。
+
+## テンプレート個別の補足
+
+### `ci.yml`
+
+- 起動: 全ブランチ push (タグ push は `tags-ignore: '**'` で除外)
+- 編集ポイント: `pnpm lint` / `pnpm test` 行はリポジトリの構成に合わせて編集する (例: `pnpm -r lint` / `pnpm -r test`、または不要な行を削除)。
+- 権限: `contents: write` (format アクションが差分を自動コミットして push するため)。
+
+### `release.yml`
+
+- 起動: `workflow_dispatch` のみ。実行時に `patch` / `minor` / `major` から選ぶ。
+- 出力: `release` ブランチに bump コミットを作成し、デフォルトブランチに向けた PR を開く。PR タイトルは `chore(release): vX.Y.Z`、本文には前タグからの compare URL を含む。
+- 編集ポイント: ブランチ名・コミットプレフィックスを変えたい場合は `env.RELEASE_BRANCH` / `env.RELEASE_COMMIT_PREFIX` を書き換える。
+- 失敗時クリーンアップ: 既存の release PR をクローズし、`release` ブランチを削除する (ベストエフォート)。
+
+### `publish.yml`
+
+- 起動: リリース PR (head=`release`、タイトル=`chore(release): ...`、fork 由来でない) のマージ、または手動 (`workflow_dispatch`)。
+- 流れ: check ジョブで対象 SHA を解決してタグ存在を確認 → 既存タグなら以降スキップ → publish ジョブで該当 SHA を checkout して npm 公開 → タグ作成 → alpha バンプ PR を作成。
+- 編集ポイント: ブランチ名は `env.RELEASE_BRANCH` / `env.PRERELEASE_BRANCH`、コミットプレフィックスは `env.RELEASE_COMMIT_PREFIX` で一括管理。pre-release identifier (現状 `alpha`) を beta / rc に変える場合は `bump-command` の `--preid` と `commit-prefix`、`pr-body`、DIST_TAG 判定の `*-alpha.*` を併せて書き換える。
+- 権限: `check` は `contents: read` のみ、`publish` は `contents: write` / `id-token: write` (Trusted Publishing) / `pull-requests: write` (alpha PR 作成)。

--- a/workflow-templates/ci.properties.json
+++ b/workflow-templates/ci.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "tuqulore CI",
+  "description": "pnpm lint と pnpm test を実行し、フォーマット差分を自動コミットする tuqulore 標準の CI ワークフロー。",
+  "categories": ["Continuous integration", "TypeScript", "JavaScript", "Node"]
+}

--- a/workflow-templates/ci.properties.json
+++ b/workflow-templates/ci.properties.json
@@ -1,5 +1,5 @@
 {
-  "name": "tuqulore CI",
+  "name": "CI",
   "description": "pnpm lint と pnpm test を実行し、フォーマット差分を自動コミットする tuqulore 標準の CI ワークフロー。",
   "categories": ["Continuous integration", "TypeScript", "JavaScript", "Node"]
 }

--- a/workflow-templates/ci.yml
+++ b/workflow-templates/ci.yml
@@ -13,6 +13,7 @@ jobs:
       contents: write
     steps:
       - uses: tuqulore/.github/setup@main
+      # pnpm スクリプトはリポジトリに合わせて編集する (例: pnpm -r lint / pnpm -r test、または不要なら削除)
       - run: pnpm lint
       - run: pnpm test
       - uses: tuqulore/.github/format@main

--- a/workflow-templates/ci.yml
+++ b/workflow-templates/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: push
+on:
+  push:
+    tags-ignore:
+      - '**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/workflow-templates/ci.yml
+++ b/workflow-templates/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ci:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: tuqulore/.github/setup@main
+      - run: pnpm lint
+      - run: pnpm test
+      - uses: tuqulore/.github/format@main

--- a/workflow-templates/publish.properties.json
+++ b/workflow-templates/publish.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "tuqulore Publish (npm, lerna monorepo)",
+  "description": "lerna monorepo を npm に公開し、リリースタグを作成して alpha バンプ PR を起こすワークフロー。chore(release): で始まるリリース PR のマージで起動する。",
+  "categories": ["Deployment", "TypeScript", "JavaScript", "Node"]
+}

--- a/workflow-templates/publish.properties.json
+++ b/workflow-templates/publish.properties.json
@@ -1,5 +1,5 @@
 {
-  "name": "tuqulore Publish (npm, lerna monorepo)",
+  "name": "Publish (npm, lerna monorepo)",
   "description": "lerna monorepo を npm に公開し、リリースタグを作成して alpha バンプ PR を起こすワークフロー。chore(release): で始まるリリース PR のマージで起動する。",
   "categories": ["Deployment", "TypeScript", "JavaScript", "Node"]
 }

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -7,10 +7,7 @@ on:
       - $default-branch
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: publish
@@ -26,6 +23,8 @@ jobs:
         startsWith(github.event.pull_request.title, 'chore(release):')
       )
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       tag-exists: ${{ steps.check-tag.outputs.tag-exists }}
     steps:
@@ -47,6 +46,10 @@ jobs:
     needs: check
     if: needs.check.outputs.tag-exists == 'false'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
       - uses: tuqulore/.github/setup@main
         with:

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -7,6 +7,10 @@ on:
       - $default-branch
   workflow_dispatch:
 
+env:
+  RELEASE_BRANCH: release
+  PRERELEASE_BRANCH: alpha
+
 permissions: {}
 
 concurrency:
@@ -19,7 +23,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.pull_request.merged == true &&
-        github.event.pull_request.head.ref == 'release' &&
+        github.event.pull_request.head.ref == env.RELEASE_BRANCH &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.title, 'chore(release):')
       )
@@ -103,7 +107,7 @@ jobs:
 
       - uses: tuqulore/.github/bump-and-pr@main
         with:
-          branch: alpha
+          branch: ${{ env.PRERELEASE_BRANCH }}
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
           commit-prefix: chore(alpha)
@@ -113,4 +117,4 @@ jobs:
 
       - name: Cleanup alpha branch on failure or cancellation
         if: failure() || cancelled()
-        run: git push origin :alpha || true
+        run: git push origin ":$PRERELEASE_BRANCH" || true

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -69,18 +69,13 @@ jobs:
 
       - uses: tuqulore/.github/configure-git@main
 
-      # 公開物とタグの指すコミットを完全に一致させるため、check ジョブで
-      # 解決した SHA を detached HEAD で checkout してから publish と tag を行う。
+      # 公開物とタグの指すコミットを一致させるため、check で解決した SHA を detached HEAD で checkout する。
       - name: Checkout target sha for publishing
         env:
           SHA: ${{ needs.check.outputs.sha }}
         run: git checkout "${SHA}"
 
-      # npm への公開は npm Trusted Publishing (OIDC) 経由を前提としている。
-      # 利用パッケージごとに npm 側で Trusted Publisher（このリポジトリの
-      # publish ワークフロー）を登録しておくこと。トークン方式に切り替える
-      # 場合は、setup-node で registry-url を設定し NODE_AUTH_TOKEN を env に
-      # 渡すなど、認証セットアップを別途追加すること。
+      # npm 公開は Trusted Publishing (OIDC) 前提。npm 側で Trusted Publisher 登録が必要 (詳細は workflow-templates/README.md)。
       - name: Publish to npm
         run: |
           VERSION=$(jq -r .version lerna.json)

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -28,9 +28,7 @@ jobs:
     outputs:
       tag-exists: ${{ steps.check-tag.outputs.tag-exists }}
     steps:
-      - uses: tuqulore/.github/setup@main
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check if tag already exists
         id: check-tag
@@ -57,6 +55,26 @@ jobs:
 
       - uses: tuqulore/.github/configure-git@main
 
+      # 公開物とタグの指すコミットを完全に一致させるため、対象 SHA を
+      # detached HEAD で checkout してから publish と tag を行う。
+      # pull_request 起動時は actions/checkout が refs/pull/X/merge を
+      # checkout するため、実際の merge_commit_sha とは別コミットになる。
+      # 本ジョブ実行中にデフォルトブランチが先に進んでも、リリース PR が
+      # 指すコミットに対して publish/tag できる。
+      # workflow_dispatch では merge_commit_sha がないので、デフォルト
+      # ブランチの最新 HEAD を対象にする。
+      - name: Checkout target sha for publishing
+        env:
+          DEFAULT_BRANCH: $default-branch
+        run: |
+          git fetch origin "${DEFAULT_BRANCH}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          else
+            SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
+          fi
+          git checkout "${SHA}"
+
       # npm への公開は npm Trusted Publishing (OIDC) 経由を前提としている。
       # 利用パッケージごとに npm 側で Trusted Publisher（このリポジトリの
       # publish ワークフロー）を登録しておくこと。トークン方式に切り替える
@@ -74,28 +92,10 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
-      # pull_request 起動時はリリース PR の merge_commit_sha に直接タグを打つ。
-      # 本ジョブ実行中にデフォルトブランチが先に進んでも、リリース PR が指すコミット
-      # に確実にタグが付く。workflow_dispatch では merge_commit_sha がないので、
-      # デフォルトブランチの最新 HEAD にタグを打つ（従来挙動）。
-      - name: Resolve target sha for release tag
-        id: target
-        env:
-          DEFAULT_BRANCH: $default-branch
-        run: |
-          git fetch origin "${DEFAULT_BRANCH}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SHA="${{ github.event.pull_request.merge_commit_sha }}"
-          else
-            SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
-          fi
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-
       - name: Create release tag
         run: |
-          SHA="${{ steps.target.outputs.sha }}"
-          VERSION=$(git show "${SHA}:lerna.json" | jq -r .version)
-          git tag "v${VERSION}" "${SHA}"
+          VERSION=$(jq -r .version lerna.json)
+          git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
       # alpha ブランチはデフォルトブランチの最新から派生させたいので checkout し直す

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -20,6 +20,7 @@ jobs:
       (
         github.event.pull_request.merged == true &&
         github.event.pull_request.head.ref == 'release' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.title, 'chore(release):')
       )
     runs-on: ubuntu-24.04

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -79,6 +79,7 @@ jobs:
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
           commit-prefix: chore(alpha)
+          pr-base: $default-branch
           pr-body: Bump to alpha version v${VERSION}
           github-token: ${{ github.token }}
 

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -62,17 +62,39 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+      # pull_request 起動時はリリース PR の merge_commit_sha に直接タグを打つ。
+      # 本ジョブ実行中にデフォルトブランチが先に進んでも、リリース PR が指すコミット
+      # に確実にタグが付く。workflow_dispatch では merge_commit_sha がないので、
+      # デフォルトブランチの最新 HEAD にタグを打つ（従来挙動）。
+      - name: Resolve target sha for release tag
+        id: target
+        env:
+          DEFAULT_BRANCH: $default-branch
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          else
+            git fetch --depth=1 origin "${DEFAULT_BRANCH}"
+            SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
+          fi
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Create release tag
+        run: |
+          SHA="${{ steps.target.outputs.sha }}"
+          git fetch origin "${SHA}"
+          VERSION=$(git show "${SHA}:lerna.json" | jq -r .version)
+          git tag "v${VERSION}" "${SHA}"
+          git push origin "v${VERSION}"
+
+      # alpha ブランチはデフォルトブランチの最新から派生させたいので checkout し直す
+      - name: Checkout default branch for alpha bump
         env:
           DEFAULT_BRANCH: $default-branch
         run: |
           git checkout "${DEFAULT_BRANCH}"
           git pull origin "${DEFAULT_BRANCH}"
-          VERSION=$(jq -r .version lerna.json)
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
 
-      # 直前の "Create release tag" がデフォルトブランチを checkout 済みのため、そこから alpha ブランチを作成する
       - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: alpha

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  check:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -23,6 +23,35 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         startsWith(github.event.pull_request.title, 'chore(release):')
       )
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      tag-exists: ${{ steps.check-tag.outputs.tag-exists }}
+      sha: ${{ steps.target.outputs.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: tuqulore/.github/resolve-target-sha@main
+        id: target
+        with:
+          default-branch: $default-branch
+
+      - name: Check if tag already exists
+        id: check-tag
+        env:
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          VERSION=$(git show "${SHA}:lerna.json" | jq -r .version)
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
+            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.tag-exists == 'false'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -35,39 +64,12 @@ jobs:
 
       - uses: tuqulore/.github/configure-git@main
 
-      # 公開物とタグの指すコミットを完全に一致させるため、対象 SHA を
-      # detached HEAD で checkout してから publish と tag を行う。
-      # pull_request 起動時は actions/checkout が refs/pull/X/merge を
-      # checkout するため、実際の merge_commit_sha とは別コミットになる。
-      # 本ジョブ実行中にデフォルトブランチが先に進んでも、リリース PR が
-      # 指すコミットに対して publish/tag できる。
-      # workflow_dispatch では merge_commit_sha がないので、デフォルト
-      # ブランチの最新 HEAD を対象にする。
+      # 公開物とタグの指すコミットを完全に一致させるため、check ジョブで
+      # 解決した SHA を detached HEAD で checkout してから publish と tag を行う。
       - name: Checkout target sha for publishing
         env:
-          DEFAULT_BRANCH: $default-branch
-        run: |
-          git fetch origin "${DEFAULT_BRANCH}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SHA="${{ github.event.pull_request.merge_commit_sha }}"
-            if [ -z "${SHA}" ]; then
-              echo "::error::pull_request.merge_commit_sha is empty. Re-run the workflow once the merge commit has been propagated." >&2
-              exit 1
-            fi
-          else
-            SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
-          fi
-          git checkout "${SHA}"
-
-      - name: Check if tag already exists
-        id: check-tag
-        run: |
-          VERSION=$(jq -r .version lerna.json)
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
-            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          SHA: ${{ needs.check.outputs.sha }}
+        run: git checkout "${SHA}"
 
       # npm への公開は npm Trusted Publishing (OIDC) 経由を前提としている。
       # 利用パッケージごとに npm 側で Trusted Publisher（このリポジトリの
@@ -75,7 +77,6 @@ jobs:
       # 場合は、setup-node で registry-url を設定し NODE_AUTH_TOKEN を env に
       # 渡すなど、認証セットアップを別途追加すること。
       - name: Publish to npm
-        if: steps.check-tag.outputs.tag-exists == 'false'
         run: |
           VERSION=$(jq -r .version lerna.json)
           if [[ "$VERSION" == *"-alpha."* ]]; then
@@ -88,7 +89,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create release tag
-        if: steps.check-tag.outputs.tag-exists == 'false'
         run: |
           VERSION=$(jq -r .version lerna.json)
           git tag "v${VERSION}"
@@ -96,14 +96,12 @@ jobs:
 
       # alpha ブランチはデフォルトブランチの最新から派生させたいので checkout し直す
       - name: Checkout default branch for alpha bump
-        if: steps.check-tag.outputs.tag-exists == 'false'
         env:
           DEFAULT_BRANCH: $default-branch
         run: |
           git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
 
       - uses: tuqulore/.github/bump-and-pr@main
-        if: steps.check-tag.outputs.tag-exists == 'false'
         with:
           branch: alpha
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
@@ -114,5 +112,5 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Cleanup alpha branch on failure or cancellation
-        if: (failure() || cancelled()) && steps.check-tag.outputs.tag-exists == 'false'
+        if: failure() || cancelled()
         run: git push origin :alpha || true

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -20,7 +20,11 @@ jobs:
   check:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release):'))
+      (
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.ref == 'release' &&
+        startsWith(github.event.pull_request.title, 'chore(release):')
+      )
     runs-on: ubuntu-24.04
     outputs:
       tag-exists: ${{ steps.check-tag.outputs.tag-exists }}

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -54,6 +54,11 @@ jobs:
 
       - uses: tuqulore/.github/configure-git@main
 
+      # npm への公開は npm Trusted Publishing (OIDC) 経由を前提としている。
+      # 利用パッケージごとに npm 側で Trusted Publisher（このリポジトリの
+      # publish ワークフロー）を登録しておくこと。トークン方式に切り替える
+      # 場合は、setup-node で registry-url を設定し NODE_AUTH_TOKEN を env に
+      # 渡すなど、認証セットアップを別途追加すること。
       - name: Publish to npm
         run: |
           VERSION=$(jq -r .version lerna.json)

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -1,0 +1,87 @@
+name: Publish
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  check:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release):'))
+    runs-on: ubuntu-24.04
+    outputs:
+      tag-exists: ${{ steps.check-tag.outputs.tag-exists }}
+    steps:
+      - uses: tuqulore/.github/setup@main
+        with:
+          fetch-depth: 0
+
+      - name: Check if tag already exists
+        id: check-tag
+        run: |
+          VERSION=$(jq -r .version lerna.json)
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
+            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.tag-exists == 'false'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: tuqulore/.github/setup@main
+        with:
+          fetch-depth: 0
+
+      - uses: tuqulore/.github/configure-git@main
+
+      - name: Publish to npm
+        run: |
+          VERSION=$(jq -r .version lerna.json)
+          if [[ "$VERSION" == *"-alpha."* ]]; then
+            DIST_TAG="alpha"
+          else
+            DIST_TAG="latest"
+          fi
+          pnpm packages:publish --yes --dist-tag "${DIST_TAG}"
+        env:
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Create release tag
+        env:
+          DEFAULT_BRANCH: $default-branch
+        run: |
+          git checkout "${DEFAULT_BRANCH}"
+          git pull origin "${DEFAULT_BRANCH}"
+          VERSION=$(jq -r .version lerna.json)
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      # 直前の "Create release tag" がデフォルトブランチを checkout 済みのため、そこから alpha ブランチを作成する
+      - uses: tuqulore/.github/bump-and-pr@main
+        with:
+          branch: alpha
+          bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(alpha)
+          pr-body: Bump to alpha version v${VERSION}
+          github-token: ${{ github.token }}
+
+      - name: Cleanup alpha branch on failure or cancellation
+        if: failure() || cancelled()
+        run: git push origin :alpha || true

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -71,10 +71,10 @@ jobs:
         env:
           DEFAULT_BRANCH: $default-branch
         run: |
+          git fetch origin "${DEFAULT_BRANCH}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             SHA="${{ github.event.pull_request.merge_commit_sha }}"
           else
-            git fetch --depth=1 origin "${DEFAULT_BRANCH}"
             SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
           fi
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
@@ -82,7 +82,6 @@ jobs:
       - name: Create release tag
         run: |
           SHA="${{ steps.target.outputs.sha }}"
-          git fetch origin "${SHA}"
           VERSION=$(git show "${SHA}:lerna.json" | jq -r .version)
           git tag "v${VERSION}" "${SHA}"
           git push origin "v${VERSION}"
@@ -92,8 +91,7 @@ jobs:
         env:
           DEFAULT_BRANCH: $default-branch
         run: |
-          git checkout "${DEFAULT_BRANCH}"
-          git pull origin "${DEFAULT_BRANCH}"
+          git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
 
       - uses: tuqulore/.github/bump-and-pr@main
         with:

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -10,6 +10,7 @@ on:
 env:
   RELEASE_BRANCH: release
   PRERELEASE_BRANCH: alpha
+  RELEASE_COMMIT_PREFIX: chore(release)
 
 permissions: {}
 
@@ -25,7 +26,7 @@ jobs:
         github.event.pull_request.merged == true &&
         github.event.pull_request.head.ref == env.RELEASE_BRANCH &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.event.pull_request.title, 'chore(release):')
+        startsWith(github.event.pull_request.title, format('{0}:', env.RELEASE_COMMIT_PREFIX))
       )
     runs-on: ubuntu-24.04
     permissions:

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
+  publish:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -22,27 +22,6 @@ jobs:
         github.event.pull_request.head.ref == 'release' &&
         startsWith(github.event.pull_request.title, 'chore(release):')
       )
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    outputs:
-      tag-exists: ${{ steps.check-tag.outputs.tag-exists }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Check if tag already exists
-        id: check-tag
-        run: |
-          VERSION=$(jq -r .version lerna.json)
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
-            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish:
-    needs: check
-    if: needs.check.outputs.tag-exists == 'false'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -75,12 +54,23 @@ jobs:
           fi
           git checkout "${SHA}"
 
+      - name: Check if tag already exists
+        id: check-tag
+        run: |
+          VERSION=$(jq -r .version lerna.json)
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
+            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # npm への公開は npm Trusted Publishing (OIDC) 経由を前提としている。
       # 利用パッケージごとに npm 側で Trusted Publisher（このリポジトリの
       # publish ワークフロー）を登録しておくこと。トークン方式に切り替える
       # 場合は、setup-node で registry-url を設定し NODE_AUTH_TOKEN を env に
       # 渡すなど、認証セットアップを別途追加すること。
       - name: Publish to npm
+        if: steps.check-tag.outputs.tag-exists == 'false'
         run: |
           VERSION=$(jq -r .version lerna.json)
           if [[ "$VERSION" == *"-alpha."* ]]; then
@@ -93,6 +83,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create release tag
+        if: steps.check-tag.outputs.tag-exists == 'false'
         run: |
           VERSION=$(jq -r .version lerna.json)
           git tag "v${VERSION}"
@@ -100,12 +91,14 @@ jobs:
 
       # alpha ブランチはデフォルトブランチの最新から派生させたいので checkout し直す
       - name: Checkout default branch for alpha bump
+        if: steps.check-tag.outputs.tag-exists == 'false'
         env:
           DEFAULT_BRANCH: $default-branch
         run: |
           git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
 
       - uses: tuqulore/.github/bump-and-pr@main
+        if: steps.check-tag.outputs.tag-exists == 'false'
         with:
           branch: alpha
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
@@ -116,5 +109,5 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Cleanup alpha branch on failure or cancellation
-        if: failure() || cancelled()
+        if: (failure() || cancelled()) && steps.check-tag.outputs.tag-exists == 'false'
         run: git push origin :alpha || true

--- a/workflow-templates/publish.yml
+++ b/workflow-templates/publish.yml
@@ -49,6 +49,10 @@ jobs:
           git fetch origin "${DEFAULT_BRANCH}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             SHA="${{ github.event.pull_request.merge_commit_sha }}"
+            if [ -z "${SHA}" ]; then
+              echo "::error::pull_request.merge_commit_sha is empty. Re-run the workflow once the merge commit has been propagated." >&2
+              exit 1
+            fi
           else
             SHA=$(git rev-parse "origin/${DEFAULT_BRANCH}")
           fi

--- a/workflow-templates/release.properties.json
+++ b/workflow-templates/release.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "tuqulore Release (lerna monorepo)",
+  "description": "lerna monorepo 向けに、指定した semver でバージョンを bump して release ブランチでリリース PR を作成するワークフロー。手動 (workflow_dispatch) で起動する。",
+  "categories": ["Deployment", "TypeScript", "JavaScript", "Node"]
+}

--- a/workflow-templates/release.properties.json
+++ b/workflow-templates/release.properties.json
@@ -1,5 +1,5 @@
 {
-  "name": "tuqulore Release (lerna monorepo)",
+  "name": "Release (lerna monorepo)",
   "description": "lerna monorepo 向けに、指定した semver でバージョンを bump して release ブランチでリリース PR を作成するワークフロー。手動 (workflow_dispatch) で起動する。",
   "categories": ["Deployment", "TypeScript", "JavaScript", "Node"]
 }

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   RELEASE_BRANCH: release
+  RELEASE_COMMIT_PREFIX: chore(release)
 
 permissions:
   contents: write
@@ -55,7 +56,7 @@ jobs:
           branch: ${{ env.RELEASE_BRANCH }}
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
-          commit-prefix: chore(release)
+          commit-prefix: ${{ env.RELEASE_COMMIT_PREFIX }}
           pr-base: $default-branch
           pr-body: |
             Release v${VERSION}

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -41,6 +41,7 @@ jobs:
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
           commit-prefix: chore(release)
+          pr-base: $default-branch
           pr-body: |
             Release v${VERSION}
 

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -32,8 +32,20 @@ jobs:
       - name: Find previous release tag
         id: previous-tag
         run: |
-          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -v -- '-' | head -n 1)
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | { grep -v -- '-' || true; } | head -n 1)
           echo "tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build changelog URL
+        id: changelog
+        env:
+          PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
+        run: |
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            URL="https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...release"
+          else
+            URL="https://github.com/${{ github.repository }}/commits/release"
+          fi
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
       - uses: tuqulore/.github/bump-and-pr@main
         with:
@@ -45,7 +57,7 @@ jobs:
           pr-body: |
             Release v${VERSION}
 
-            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.previous-tag.outputs.tag }}...release
+            **Full Changelog**: ${{ steps.changelog.outputs.url }}
           github-token: ${{ github.token }}
 
       - name: Cleanup on failure or cancellation

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()
         run: |
-          EXISTING_PR=$(gh pr list --base $DEFAULT_BRANCH --head release --json number --jq '.[0].number // empty' 2>/dev/null)
+          EXISTING_PR=$(gh pr list --base "$DEFAULT_BRANCH" --head release --json number --jq '.[0].number // empty' 2>/dev/null)
           if [ -n "$EXISTING_PR" ]; then
             gh pr close "$EXISTING_PR"
           fi

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,0 +1,60 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: next semantic version(s) value
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: tuqulore/.github/setup@main
+        with:
+          fetch-depth: 0
+
+      - uses: tuqulore/.github/configure-git@main
+
+      - name: Find previous release tag
+        id: previous-tag
+        run: |
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -v -- '-' | head -n 1)
+          echo "tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: tuqulore/.github/bump-and-pr@main
+        with:
+          branch: release
+          bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(release)
+          pr-body: |
+            Release v${VERSION}
+
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.previous-tag.outputs.tag }}...release
+          github-token: ${{ github.token }}
+
+      - name: Cleanup on failure or cancellation
+        if: failure() || cancelled()
+        run: |
+          EXISTING_PR=$(gh pr list --base $DEFAULT_BRANCH --head release --json number --jq '.[0].number // empty' 2>/dev/null)
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR"
+          fi
+          git push origin :release || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: $default-branch

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -63,9 +63,9 @@ jobs:
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()
         run: |
-          EXISTING_PR=$(gh pr list --base "$DEFAULT_BRANCH" --head release --json number --jq '.[0].number // empty' 2>/dev/null)
+          EXISTING_PR=$(gh pr list --base "$DEFAULT_BRANCH" --head release --json number --jq '.[0].number // empty' 2>/dev/null || true)
           if [ -n "$EXISTING_PR" ]; then
-            gh pr close "$EXISTING_PR"
+            gh pr close "$EXISTING_PR" || true
           fi
           git push origin :release || true
         env:

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -11,6 +11,9 @@ on:
           - minor
           - major
 
+env:
+  RELEASE_BRANCH: release
+
 permissions:
   contents: write
   pull-requests: write
@@ -41,15 +44,15 @@ jobs:
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
         run: |
           if [ -n "${PREVIOUS_TAG}" ]; then
-            URL="https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...release"
+            URL="https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${RELEASE_BRANCH}"
           else
-            URL="https://github.com/${{ github.repository }}/commits/release"
+            URL="https://github.com/${{ github.repository }}/commits/${RELEASE_BRANCH}"
           fi
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
       - uses: tuqulore/.github/bump-and-pr@main
         with:
-          branch: release
+          branch: ${{ env.RELEASE_BRANCH }}
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
           version-command: jq -r .version lerna.json
           commit-prefix: chore(release)
@@ -62,12 +65,12 @@ jobs:
 
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()
-        run: |
-          EXISTING_PR=$(gh pr list --base "$DEFAULT_BRANCH" --head release --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          if [ -n "$EXISTING_PR" ]; then
-            gh pr close "$EXISTING_PR" || true
-          fi
-          git push origin :release || true
         env:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: $default-branch
+        run: |
+          EXISTING_PR=$(gh pr list --base "$DEFAULT_BRANCH" --head "$RELEASE_BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" || true
+          fi
+          git push origin ":$RELEASE_BRANCH" || true

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Find previous release tag
         id: previous-tag
         run: |
-          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | { grep -v -- '-' || true; } | head -n 1)
+          PREVIOUS_TAG=$(git tag -l 'v*' --sort=-v:refname | { grep -v -- '-' || true; } | sed -n '1p')
           echo "tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build changelog URL


### PR DESCRIPTION
## Summary

- 組織共通のワークフローテンプレートとして `workflow-templates/` ディレクトリに 3 つのテンプレートを追加
  - `ci.yml`: 4 リポジトリ共通の lint/test + format パターン
  - `release.yml`: lerna monorepo 向けの workflow_dispatch 起動リリース PR 作成（jumpu-ui / website-boilerplate 同型）
  - `publish.yml`: lerna monorepo 向けの npm 公開 + タグ作成 + alpha バンプ PR（website-boilerplate を踏襲）
- 各テンプレートは `tuqulore/.github/{setup,configure-git,format,bump-and-pr}@main` を参照
- `$default-branch` プレースホルダで Publish のトリガー / タグ作成時の checkout 先 / Release クリーンアップ時の `--base` を可搬化

## 参考

- [組織のワークフロー テンプレートを作成する - GitHub Docs](https://docs.github.com/ja/actions/how-tos/sharing-automations/creating-workflow-templates-for-your-organization)
- 参考にしたリポジトリ: tuqulore/tuqulore.com, tuqulore/earth-ek, tuqulore/jumpu-ui, tuqulore/website-boilerplate
- Preview (Cloud Run) は earth-ek 固有度が高く、テンプレ化対象外とした

Closes #13

## Test plan

- [ ] 組織の Actions タブから「New workflow」を開き、3 テンプレートが表示されることを確認
- [ ] 各テンプレートから新規ワークフローを生成し、`$default-branch` がリポジトリのデフォルトブランチに置換されることを確認
- [ ] 生成されたワークフローが想定通り動作することを確認（CI を任意のリポジトリで試す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)